### PR TITLE
Hashimoto/darkpool

### DIFF
--- a/pams/agents/darkpool_agent.py
+++ b/pams/agents/darkpool_agent.py
@@ -1,11 +1,10 @@
 from typing import Any
 from typing import Dict
 from typing import List
-from typing import Optional
 from typing import Union
 
 from ..market import Market
-from ..order import Order, Cancel, MARKET_ORDER, LIMIT_ORDER
+from ..order import Order, Cancel, MARKET_ORDER
 from .fcn_agent import FCNAgent
 
 class DarkPoolFCNAgent(FCNAgent):
@@ -48,7 +47,7 @@ class DarkPoolFCNAgent(FCNAgent):
     def submit_orders(self, markets: List[Market]) -> List[Union[Order, Cancel]]:
         """submit orders based on FCN-based calculation.
 
-        submit limit order to litMarket first, and then change the order destination to DarkPoolMarket with probability 1-d.
+        Create limit order to litMarket first, and then change the order destination to DarkPoolMarket with probability 1-d.
         .. seealso::
             - :func:`pams.agents.Agent.submit_orders`
         """

--- a/pams/agents/darkpool_agent.py
+++ b/pams/agents/darkpool_agent.py
@@ -1,0 +1,66 @@
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Union
+
+from ..market import Market
+from ..order import Order, Cancel, MARKET_ORDER, LIMIT_ORDER
+from .fcn_agent import FCNAgent
+
+class DarkPoolFCNAgent(FCNAgent):
+    """Dark Pool FCN Agent class
+
+    This class inherits from the :class:`pams.agents.Agent` class.
+
+    The agent perceives single pair of (litMarket, DarkPoolMarket)
+    and decides which market to submit orders to with a given probability "d".
+    """  # NOQA
+    def setup(
+        self, settings: Dict[str, Any],
+        accessible_markets_ids: List[int]
+    ) -> None:
+        """agent setup.  Usually be called from simulator/runner automatically.
+
+        Args:
+            settings (Dict[str, Any]): agent configuration.
+                                       This must include the parameters "d" and "DarkPoolMarket".
+                                       This can include the parameters "fundamentalWeight", "chartWeight",
+                                       "noiseWeight", "noiseScale", "timeWindowSize", "orderMargin", "marginType",
+                                       and "meanReversionTime".
+            accessible_markets_ids (List[int]): list of market IDs. len(accessible_markets_ids) must be 2.
+
+        Returns:
+            None
+        """
+        if "d" not in settings:
+            raise ValueError("d is required for DarkPoolAgent")
+        if "DarkPoolMarket" not in settings:
+            raise ValueError("DarkPoolMarket is required for DarkPoolAgent")
+        if len(accessible_markets_ids) != 2:
+            raise ValueError("len(accessible_markets_ids) is not 2. Only single pair or litMarket and DarkPoolMarket can exists.")
+        super().setup(settings=settings,
+                    accessible_markets_ids=accessible_markets_ids)
+        self.d: float = float(settings["d"])
+        self.darkpool_market: Market = \
+        self.simulator.name2market[settings["DarkPoolMarket"]]
+
+    def submit_orders(self, markets: List[Market]) -> List[Union[Order, Cancel]]:
+        """submit orders based on FCN-based calculation.
+
+        submit limit order to litMarket first, and then change the order destination to DarkPoolMarket with probability 1-d.
+        .. seealso::
+            - :func:`pams.agents.Agent.submit_orders`
+        """
+        markets.remove(self.darkpool_market)
+        orders: List[Union[Order, Cancel]] = super().submit_orders(markets)
+        markets.append(self.darkpool_market)
+        is_order_to_lit: bool = \
+        self.prng.choices([False,True], cum_weights=[1-self.d,1], k=1)[0]
+        if not is_order_to_lit:
+            for i, order in enumerate(orders):
+                order.market_id = self.darkpool_market.market_id
+                order.price = None
+                order.kind = MARKET_ORDER
+                orders[i] = order
+        return orders

--- a/pams/darkpool_market.py
+++ b/pams/darkpool_market.py
@@ -1,0 +1,45 @@
+from typing import Any
+from typing import Dict
+from typing import List
+
+from .logs.base import ExecutionLog
+from .market import Market
+from .order import Order
+
+class DarkPoolMarket(Market):
+    def setup(self, settings: Dict[str, Any]) -> None:
+        """setup market configuration from setting format.
+
+        Args:
+            settings (Dict[str, Any]): market configuration. Usually, automatically set from json config of simulator.
+                                       This must include the parameters "tickSize", "litMarket" and either "marketPrice" or "fundamentalPrice".
+                                       This can include the parameter "outstandingShares".
+
+        Returns:
+            None
+        """
+        super().setup(settings)
+        if "litMarket" not in settings:
+            raise ValueError("litMarket is required for DarkPoolMarket")
+        self.lit_market: Market = \
+        self.simulator.name2market[settings["litMarket"]]
+
+    def _execution(self) -> List[ExecutionLog]:
+        """execute for market. (Usually, only triggered by runner)
+
+        Returns:
+            List[:class:`pams.logs.base.ExecutionLog`]: execution logs.
+        """
+        logs: List[ExecutionLog] = []
+        while True:
+            if len(self.sell_order_book.priority_queue) == 0 or \
+            len(self.buy_order_book.priority_queue) == 0:
+                break
+            buy_order: Order = self.buy_order_book.priority_queue[0]
+            sell_order: Order = self.sell_order_book.priority_queue[0]
+            sellbuy_order_volumes: List[int] = [sell_order.volume, buy_order.volume]
+            volume: int = min(sellbuy_order_volumes)
+            log = self._execute_orders(self.lit_market.get_mid_price(), volume,
+                                    buy_order, sell_order)
+            logs.append(log)
+        return logs

--- a/pams/runners/sequential.py
+++ b/pams/runners/sequential.py
@@ -216,7 +216,7 @@ class SequentialRunner(Runner):
             )
             if not issubclass(agent_class, Agent):
                 raise ValueError(
-                    f"market class for {name} does not inherit Market class"
+                    f"agent class for {name} does not inherit Agent class"
                 )
             if "markets" not in agent_settings:
                 raise ValueError(f"markets is required in {name}")


### PR DESCRIPTION
## correct typo

In ```runner/sequential.py``` line 219, ```f"market class for {name} does not inherit Market class"``` is changed to ```f"agent class for {name} does not inherit Agent class"```

## DarkPoolAgent, DarkPoolMarket

Added ```pams/agents/darkpool_agent.py```, ```darkpool_market.py```

### Usage

```python
config = {
	"simulation": {
		"markets": ["litMarket", "DarkPoolMarket"],
		"agents": ["DarkPoolFCNAgents"],
		"sessions": [
			{	"sessionName": 0,
				"iterationSteps": 100,
				"withOrderPlacement": True,
				"withOrderExecution": False,
				"withPrint": True,
				"hiFrequencySubmitRate": 1.0
			},
			{	"sessionName": 1,
				"iterationSteps": 4000,
				"withOrderPlacement": True,
				"withOrderExecution": True,
				"withPrint": True
			}
		]
	},
	"litMarket": {
		"class": "Market",
		"tickSize": 0.00001,
		"marketPrice": 300.0,
	},
	"DarkPoolMarket": {
		  "class": "DarkPoolMarket",
		  "litMarket": "litMarket",
		  "tickSize": 0.00001,
		  "marketPrice": 300.0
	},
	"DarkPoolFCNAgents": {
		"class": "DarkPoolFCNAgent",
		"numAgents": 100,
		"markets": ["litMarket", "DarkPoolMarket"],
		"DarkPoolMarket": "DarkPoolMarket",
		"assetVolume": 50,
		"cashAmount": 10000,
		"fundamentalWeight": {"expon": [1]},
		"chartWeight": {"expon": [1.0]},
		"noiseWeight": {"expon": [1.0]},
		"meanReversionTime":{"uniform":[50,100]},
		"noiseScale": 0.001,
		"timeWindowSize": [100, 200],
		"orderMargin": [0.0, 0.1],
		"d": 0.5,
	}
}

saver = MarketStepSaver()
runner = SequentialRunner(
    settings=config,
    prng=random.Random(42),
    logger=saver
)
runner.class_register(DarkPoolFCNAgent)
runner.class_register(DarkPoolMarket)
runner.main()
```